### PR TITLE
feat: add initials utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",

--- a/src/components/SurgeryCard.tsx
+++ b/src/components/SurgeryCard.tsx
@@ -3,6 +3,7 @@ import { Clock, User, Stethoscope, FileText, Users } from 'lucide-react';
 import { Surgery } from '../types/surgery';
 import { StatusBadge } from './StatusBadge';
 import { ProgressBar } from './ProgressBar';
+import { getInitials } from '../utils/string';
 
 interface SurgeryCardProps {
   surgery: Surgery;
@@ -30,7 +31,7 @@ export const SurgeryCard: React.FC<SurgeryCardProps> = ({ surgery }) => {
         <div className="flex items-start gap-2">
           <User className="w-4 h-4 text-gray-400 mt-0.5 flex-shrink-0" />
           <div>
-            <div className="text-sm font-medium text-gray-900">{surgery.patient}</div>
+            <div className="text-sm font-medium text-gray-900">{getInitials(surgery.patient)}</div>
             <div className="text-xs text-gray-500">Paciente</div>
           </div>
         </div>

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { getInitials } from './string';
+
+describe('getInitials', () => {
+  it('converts a full name to initials', () => {
+    expect(getInitials('Camila Cuidado Santos')).toBe('CCS');
+  });
+
+  it('handles extra spaces between names', () => {
+    expect(getInitials('  John   Doe ')).toBe('JD');
+  });
+});

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,7 @@
+export function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map(part => part[0].toUpperCase())
+    .join('');
+}


### PR DESCRIPTION
## Summary
- add `getInitials` helper
- show patient initials in surgery card
- add unit tests for initials helper

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5913677f88328ac17109b2d62347e